### PR TITLE
Update bootstrap_moonlight-qt.sh

### DIFF
--- a/resources/bin/bootstrap_moonlight-qt.sh
+++ b/resources/bin/bootstrap_moonlight-qt.sh
@@ -14,7 +14,7 @@
 
 set -e
 
-. /etc/profile
+#. /etc/profile
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
Not sure what this change does from a proper point. But commenting it out makes moonlight launch on my Linux Mint 20.2 with kodi 19.4 (i have not tested further but will try to tomorrow evening)

Thank you for this, i was in the early stages of removing the docker parts of this add on so i could run it on my box. I will help where and if you need me to.