### PR TITLE
Fix ALSA device_name in LibreELEC 12

### DIFF
--- a/moonlight.py
+++ b/moonlight.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import xbmc
 import xbmcgui
+import re
 from xbmcvfs import translatePath
 
 
@@ -244,6 +245,9 @@ def speaker_setup_write_alsa_config(addon):
 
     service, device_name = get_kodi_audio_device()
     template = pathlib.Path(asoundrc_template_path).read_text()
+
+    # Remove breaking part of the device name (LibreELEC 12)
+    device_name = re.sub('\|.*', '', device_name)
 
     # Only set default device if a non-default device is configured
     if device_name == 'default':


### PR DESCRIPTION
LibreELEC 12 returns a device_name like "sysdefault:CARD=vc4hdmi0|vc4-hdmi-0 (vc4hdmi0)", but actually only the first part is needed. If the second part is not removed, ALSA complains about not finding the correct device and no sound can be heard.

Closes #42