### PR TITLE
Fixed French translation

### DIFF
--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -56,11 +56,11 @@ msgstr "Par défaut"
 
 msgctxt "#30009"
 msgid "EGL output"
-msgstr "EGL sortie"
+msgstr "Sortie EGL"
 
 msgctxt "#30010"
 msgid "Force to use a specific output on EGL systems like the Raspberry Pi."
-msgstr "Forcer à utiliser une sortie spécifique sur les systèmes EGL comme le Raspberry Pi."
+msgstr "Force l'utilisation d'une sortie spécifique sur les systèmes EGL comme le Raspberry Pi."
 
 msgctxt "#30020"
 msgid "ALSA"


### PR DESCRIPTION
This pull request fixes the French translation strings for the new EGL output option.
As always I've checked that the translations are correctly displayed using the latest LibreElec version on my Raspberry Pi 4.
I've actually noticed some issues with UI scale while trying it out, I might create an issue about it.