### PR TITLE
Use debian bookworm for rpi platform

### DIFF
--- a/resources/build/rpi/Dockerfile
+++ b/resources/build/rpi/Dockerfile
@@ -1,11 +1,11 @@
 
 # Use latest compatible Debian version
-FROM arm32v7/debian:bullseye-slim
+FROM arm32v7/debian:bookworm-slim
 
 # See Installing Moonlight Qt on Raspberry Pi 4 (https://github.com/moonlight-stream/moonlight-docs/wiki/Installing-Moonlight-Qt-on-Raspberry-Pi-4)
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y curl apt-transport-https ca-certificates gnupg \
- && echo "deb http://archive.raspberrypi.org/debian/ bullseye main" >> /etc/apt/sources.list \
+ && echo "deb http://archive.raspberrypi.org/debian/ bookworm main" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 82B129927FA3303E \
  && curl -1sLf 'https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-qt/setup.deb.sh' | distro=raspbian bash - \
  && apt-get update \


### PR DESCRIPTION
On an RaspberryPi 3 and LibreELEC 12, the plugin is not working, see #83.
I can make moonlight-qt work by changing the docker container from arm32v7/debian:bullseye-slim to arm32v7/debian:bookworm-slim.
RaspberryPi 4 and 5 use the rpi_aarch64 build that is already on bookworm, so they should not be affected by this change. I have not tested the plugin with LibreELEC on a RasperryPi 2, if it works at all.
