### PR TITLE
Add build resources for rockchip devices

### DIFF
--- a/resources/build/rockchip/Dockerfile
+++ b/resources/build/rockchip/Dockerfile
@@ -1,0 +1,18 @@
+
+# Use latest compatible Debian version
+FROM arm64v8/debian:bookworm-slim
+
+# See Installing Moonlight Qt on Raspberry Pi 4 (https://github.com/moonlight-stream/moonlight-docs/wiki/Installing-Moonlight-Qt-on-Raspberry-Pi-4)
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y curl apt-transport-https ca-certificates gnupg \
+ && curl -1sLf 'https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-qt/setup.deb.sh' | bash - \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y moonlight-qt \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Script to copy the needed libraries
+COPY create_standalone_moonlight_qt.sh /tmp/
+RUN chmod a+x /tmp/create_standalone_moonlight_qt.sh
+
+ENTRYPOINT [ "/tmp/create_standalone_moonlight_qt.sh" ]

--- a/resources/build/rockchip/create_standalone_moonlight_qt.sh
+++ b/resources/build/rockchip/create_standalone_moonlight_qt.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Make sure al needed files end up in /tmp/moonlight-qt/
+
+set -e
+
+cd "$(dirname "$0")"
+
+mkdir -p /tmp/moonlight-qt/lib/
+
+# Include dependencies not present in LibreELEC
+DEPENDENCIES="
+  libGL.so*
+  libGLX.so*
+  libGLdispatch.so*
+  libQt5*
+  libX11.so*
+  libXau.so*
+  libXdmcp.so*
+  libbsd.so*
+  libdouble-conversion.so*
+  libffi.so*
+  libgssapi_krb5.so*
+  libgudev-1.0.so*
+  libicudata.so*
+  libicui18n.so*
+  libicuuc.so*
+  libjpeg.so*
+  libk5crypto.so*
+  libkrb5.so*
+  libkrb5support.so*
+  libpcre2-16.so*
+  libpcre2-8.so*
+  libmd.so*
+  libmd4c.so*
+  libmtdev.so*
+  libopus.so*
+  libpng16.so*
+  libxcb.so*
+  libzstd.so*
+  libwayland-client.so*
+  qt5
+"
+
+LIB_DEPENDENCIES="
+  libcom_err.so*
+  libkeyutils.so*
+  libdbus-1.so*
+  liblzma.so*
+"
+
+for DEP in $DEPENDENCIES; do
+  cp --verbose --no-dereference --recursive /usr/lib/aarch64-linux-gnu/$DEP /tmp/moonlight-qt/lib/
+done
+
+# Dependencies from /lib
+for DEP in $LIB_DEPENDENCIES; do
+  cp --verbose --no-dereference --recursive /lib/aarch64-linux-gnu/$DEP /tmp/moonlight-qt/lib/
+done
+
+mkdir /tmp/moonlight-qt/bin/
+cp -v /usr/bin/moonlight-qt /tmp/moonlight-qt/bin/
+
+chown -R --reference=/tmp/moonlight-qt /tmp/moonlight-qt/


### PR DESCRIPTION
Add support for Rockchip devices. Tested on rock64 (rk3328) with libreelec-12 nightly build.