### PR TITLE
Custom Moonlight launch method

### DIFF
--- a/resources/bin/get-platform.sh
+++ b/resources/bin/get-platform.sh
@@ -8,7 +8,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-for file in /etc/os-release /usr/lib/os-release; do
+for file in /etc/moonlight/kodi-addon /etc/os-release /usr/lib/os-release; do
   if [ -f $file ]; then
     source $file
     break
@@ -36,6 +36,10 @@ fi
 # Figure out distro (libreelec, ubuntu)
 PLATFORM_DISTRO="$ID"
 PLATFORM_DISTRO_RELEASE="$VERSION_ID"
+
+if [ "$PLATFORM_DISTRO" == "custom" ]; then
+  PLATFORM="custom"
+fi
 
 if [ -d "../build/$PLATFORM" ]; then
   echo "Platform $PLATFORM ($PLATFORM_ARCH) running $PLATFORM_DISTRO $PLATFORM_DISTRO_RELEASE detected..."

--- a/resources/bin/kodi_hooks/custom/start.sh
+++ b/resources/bin/kodi_hooks/custom/start.sh
@@ -1,0 +1,1 @@
+trap "sudo systemctl start kodi.service" EXIT

--- a/resources/bin/kodi_hooks/custom/stop.sh
+++ b/resources/bin/kodi_hooks/custom/stop.sh
@@ -1,0 +1,1 @@
+sudo systemctl stop kodi.service

--- a/resources/build/custom/create_standalone_moonlight_qt.sh
+++ b/resources/build/custom/create_standalone_moonlight_qt.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Make sure al needed files end up in /tmp/moonlight-qt/
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Destination for the executable
+TARGET_PATH="$TMP_PATH/bin/moonlight-qt"
+
+
+# Create symlink
+mkdir -p "$(dirname "$TARGET_PATH")"
+ln -s /usr/local/bin/moonlight-usbip "${TARGET_PATH}"


### PR DESCRIPTION
This is a proof of concept for a way to add a custom install and launch method. The use case is having a custom binary to launch (in my case, a wrapper script) and Kodi being started and stopped as a system service (for now using sudo) - everyhing being indipendent on the platform because it's a custom setup.

I used a terrible hack to choose the "custom" platform by reading from a custom file that looks like this:

```
# /etc/moonlight/kodi-addon
ID=debian
```

I'd like to get your ideas (or possibly some other workaround that you can think of) for doing this. After that I could improve on this PR and maybe get it merged eventually. Thanks!