### PR TITLE
Update dependencies and fix plugin path

### DIFF
--- a/resources/bin/bootstrap_moonlight-qt.sh
+++ b/resources/bin/bootstrap_moonlight-qt.sh
@@ -48,7 +48,7 @@ if [ -d "$MOONLIGHT_PATH/lib" ]; then
     echo "Using Qt library from $LIB_PATH/qt6..."
     export QML_IMPORT_PATH=$LIB_PATH/qt6/qml/
     export QML2_IMPORT_PATH=$LIB_PATH/qt6/qml/
-    export QT_QPA_PLATFORM_PLUGIN_PATH=$LIB_PATH/qt6/plugins/
+    export QT_PLUGIN_PATH=$LIB_PATH/qt6/plugins/
   elif [ -d "$LIB_PATH/qt5" ]; then
     # Setup Qt5 library locations if present
     echo "Using Qt library from $LIB_PATH/qt5..."

--- a/resources/build/libreelec/create_standalone_moonlight_qt.sh
+++ b/resources/build/libreelec/create_standalone_moonlight_qt.sh
@@ -21,13 +21,17 @@ fi
 
 # Include dependencies not present in LibreELEC
 USR_DEPENDENCIES="
+  libEGL.so*
   libGL.so*
   libGLX.so*
   libGLdispatch.so*
   libICE.so*
+  libOpenCL.so*
+  libOpenGL.so*
   libQt5*
   libQt6*
   libSM.so*
+  libSvtAv1Enc.so*
   libX11-xcb.so*
   libX11.so*
   libXau.so*
@@ -37,33 +41,85 @@ USR_DEPENDENCIES="
   libXfixes.so*
   libXi.so*
   libXrender.so*
+  libaom.so*
   libatomic.so*
+  libavcodec.so*
+  libavutil.so*
+  libb2.so*
+  libbrotlicommon.so*
+  libbrotlidec.so*
+  libbrotlienc.so*
   libbsd.so*
+  libcodec2.so*
+  libcom_err.so*
   libcrypto.so*
+  libdatrie.so*
+  libdav1d.so*
   libdouble-conversion.so*
   libffi.so*
+  libfribidi.so*
+  libgdk_pixbuf-2.0.so*
+  libgomp.so*
+  libgpg-error.so*
+  libgraphite2.so*
+  libgsm.so*
   libgssapi_krb5.so*
   libgudev-1.0.so*
+  libhwy.so*
   libicudata.so*
   libicui18n.so*
   libicuuc.so*
   libinput.so*
   libjpeg.so*
+  libjxl.so*
+  libjxl_threads.so*
   libk5crypto.so*
+  libkeyutils.so*
   libkrb5.so*
   libkrb5support.so*
+  liblcms2.so*
+  liblz4.so*
+  liblzma.so*
   libmd.so*
   libmd4c.so*
+  libmp3lame.so*
   libmtdev.so*
+  libnuma.so*
+  libogg.so*
+  libopenjp2.so*
   libopus.so*
+  libpango-1.0.so*
+  libpangocairo-1.0.so*
+  libpangoft2-1.0.so*
   libpcre2-16.so*
   libpcre2-8.so*
   libpng16.so*
+  libproxy.so*
+  librav1e.so*
+  librsvg-2.so*
+  libshine.so*
+  libsnappy.so*
+  libsoxr.so*
   libssl.so*
+  libswscale.so*
+  libthai.so*
+  libtheoradec.so*
+  libtheoraenc.so*
+  libts.so*
+  libtwolame.so*
+  libva-drm.so*
   libva-wayland.so*
   libva-x11.so*
+  libva.so*
   libvdpau.so*
+  libvorbis.so*
+  libvorbisenc.so*
+  libvpx.so*
   libwayland-client.so*
+  libwebp.so*
+  libwebpmux.so*
+  libx264.so*
+  libx265.so*
   libxcb-dri3.so*
   libxcb-icccm.so*
   libxcb-image.so*
@@ -82,7 +138,9 @@ USR_DEPENDENCIES="
   libxcb.so*
   libxkbcommon-x11.so*
   libxkbcommon.so*
+  libxvidcore.so*
   libzstd.so*
+  libzvbi.so*
   vdpau/*
   qt5
   qt6


### PR DESCRIPTION
Adds the new shared library dependencies pulled in by ffmpeg and others from the latest version of Moonlight. Also uses `QT_PLUGIN_PATH` rather than `QT_QPA_PLATFORM_PLUGIN_PATH` which now seems to require pointing to `plugins/platform`, and would require setting other environment variables for the other plugins.

This has been tested on LibreELEC 12.0.2 on a Raspberry Pi 4, and on LibreELEC 12.2.0 on a Raspberry Pi 5.

Fixes #93