### PR TITLE
Add library in create_standalone_moonlight_qt.sh

### DIFF
--- a/resources/build/libreelec/create_standalone_moonlight_qt.sh
+++ b/resources/build/libreelec/create_standalone_moonlight_qt.sh
@@ -84,6 +84,7 @@ USR_DEPENDENCIES="
   libmd4c.so*
   libmp3lame.so*
   libmtdev.so*
+  libnuma.so*
   libogg.so*
   libopenjp2.so*
   libopus.so*


### PR DESCRIPTION
On Raspberry Pi 5, running v0.5.1 on LibreElec 12.2.0 results in

```
LibreELEC project: RPi version 12.2
LibreELEC arch: RPi5.aarch64
Platform rpi (aarch64) running libreelec 12.2 detected...
Loading LibreELEC profile for setting up environment...
Using custom libraries from /storage/.kodi/userdata/addon_data/plugin.program.moonlight-qt/moonlight-qt/lib...
Using Qt library from /storage/.kodi/userdata/addon_data/plugin.program.moonlight-qt/moonlight-qt/lib/qt6...
Running without window manager...
Detected resolution 1920,1080...
Using Qt scale factor 0.64...
Using Kodi hooks for libreelec...
--- Starting Moonlight ---
./moonlight-qt: error while loading shared libraries: libnuma.so.1: cannot open shared object file: No such file or directory
```

Adding `libnuma.so*` to the list of libraries to copy in `resources/build/libreelec/create_standalone_moonlight_qt.sh` solves the issue.
I have not tested this on older Raspberry Pi versions.